### PR TITLE
several updates & fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "byte"
 version = "0.2.6"
+edition = "2021"
 authors = ["andylokandy"]
 license = "MIT/Apache-2.0"
 

--- a/README.md
+++ b/README.md
@@ -4,26 +4,19 @@
 [![crates.io](https://img.shields.io/crates/v/byte.svg)](https://crates.io/crates/byte)
 [![docs.rs](https://docs.rs/byte/badge.svg)](https://docs.rs/byte)
 
-A low-level, zero-copy and panic-free serializer and deserializer for binary.
+A low-level, zero-copy and panic-free binary serializer and deserializer.
 
 ### [**Documentation**](https://docs.rs/byte)
 
 ## Usage
 
-First, add the following to your `Cargo.toml`:
-
+Add the following to your `Cargo.toml`:
 ```toml
 [dependencies]
 byte = "0.2"
 ```
 
-Next, add this to your crate root:
-
-```rust
-extern crate byte;
-```
-
-`Byte` is `no_std` library; it can directly be used in a `#![no_std]` situation or crate.
+`Byte` is a `no_std` library; it can be used in any `#![no_std]` situation or crate.
 
 
 # Overview
@@ -32,7 +25,7 @@ extern crate byte;
 A classical use case is I2C communication en/decoding.
 
 `Byte` provides two core traits `TryRead` and `TryWrite`.
-Types that implement these traits can be serialize into or deserialize from byte slices.
+Types that implement these traits can be serialized into or deserialized from byte slices.
 
 The library is meant to be simple, and it will always be.
 

--- a/src/ctx/bool.rs
+++ b/src/ctx/bool.rs
@@ -1,4 +1,4 @@
-use {check_len, Result, TryRead, TryWrite};
+use crate::{check_len, Result, TryRead, TryWrite};
 
 impl<'a> TryRead<'a> for bool {
     #[inline]

--- a/src/ctx/bytes.rs
+++ b/src/ctx/bytes.rs
@@ -1,4 +1,4 @@
-use {check_len, Error, Result, TryRead, TryWrite};
+use crate::{check_len, Error, Result, TryRead, TryWrite};
 
 /// Context for &[u8] to determine where the slice ends.
 ///
@@ -39,7 +39,7 @@ impl<'a> TryRead<'a, Bytes> for &'a [u8] {
         let len = match ctx {
             Bytes::Len(len) => check_len(bytes, len)?,
             Bytes::Pattern(pattern) => {
-                if pattern.len() == 0 {
+                if pattern.is_empty() {
                     return Err(Error::BadInput {
                         err: "Pattern is empty",
                     });
@@ -52,7 +52,7 @@ impl<'a> TryRead<'a, Bytes> for &'a [u8] {
                     .ok_or(Error::Incomplete)?
             }
             Bytes::PatternUntil(pattern, len) => {
-                if pattern.len() == 0 {
+                if pattern.is_empty() {
                     return Err(Error::BadInput {
                         err: "Pattern is empty",
                     });

--- a/src/ctx/str.rs
+++ b/src/ctx/str.rs
@@ -1,5 +1,5 @@
+use crate::{check_len, Error, Result, TryRead, TryWrite};
 use core::str;
-use {check_len, Error, Result, TryRead, TryWrite};
 
 /// Context for &str to determine where a &str ends.
 ///


### PR DESCRIPTION
Hi! first of all thanks for creating this nice crate.

I've updated & fixed several things. Please feel free to change or discuss anything that you'd prefer to be done differently.

List of changes:

- update to edition 2021
  - add "edition" key to Cargo.toml
  - add `crate::` prefix when needed.
  - remove the instructions for using `extern` which are no longer needed.
- fix several clippy lints:
  - `useless_asref`
  - `len_zero`
  - `transmute_int_to_float` & `transmute_float_to_int` (effectively removing all the remaining unsafe code).
- add attribute that forbids unsafe code, for clarity.
- fix multiple typos and expressions in the documentation.
- rustfmt.