### PR TITLE
Measure trait and dynamic buffers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,6 @@ categories = ["no-std", "embedded", "encoding", "parsing"]
 [dev-dependencies]
 quickcheck = "0.3"
 byteorder = "1.0.0"
+
+[features]
+alloc = []

--- a/src/ctx/bool.rs
+++ b/src/ctx/bool.rs
@@ -1,4 +1,11 @@
-use crate::{check_len, Result, TryRead, TryWrite};
+use crate::{check_len, Measure, Result, TryRead, TryWrite};
+
+impl<Ctx> Measure<Ctx> for bool {
+    #[inline]
+    fn measure(self, _: Ctx) -> usize {
+        1
+    }
+}
 
 impl<'a> TryRead<'a> for bool {
     #[inline]

--- a/src/ctx/num.rs
+++ b/src/ctx/num.rs
@@ -1,7 +1,6 @@
 #![allow(unused_parens)]
 
-use crate::{check_len, Error, Result, TryRead, TryWrite};
-use core::convert::TryInto;
+use crate::{check_len, Error, Measure, Result, TryRead, TryWrite};
 use core::mem;
 
 /// Endiannes of numbers.
@@ -53,6 +52,13 @@ pub const NATIVE: Endian = BE;
 
 macro_rules! num_impl {
     ($ty: ty, $size: tt) => {
+        impl<Ctx> Measure<Ctx> for $ty {
+            #[inline]
+            fn measure(self, _: Ctx) -> usize {
+                ::core::mem::size_of::<$ty>()
+            }
+        }
+
         impl<'a> TryRead<'a, Endian> for $ty {
             #[inline]
             fn try_read(bytes: &'a [u8], endian: Endian) -> Result<(Self, usize)> {
@@ -108,6 +114,13 @@ num_impl!(isize, (mem::size_of::<isize>()));
 
 macro_rules! float_impl {
     ($ty: ty, $base: ty) => {
+        impl<Ctx> Measure<Ctx> for $ty {
+            #[inline]
+            fn measure(self, _: Ctx) -> usize {
+                ::core::mem::size_of::<$ty>()
+            }
+        }
+
         impl<'a> TryRead<'a, Endian> for $ty {
             #[inline]
             fn try_read(bytes: &'a [u8], endian: Endian) -> Result<(Self, usize)> {

--- a/src/ctx/str.rs
+++ b/src/ctx/str.rs
@@ -1,4 +1,4 @@
-use crate::{check_len, Error, Result, TryRead, TryWrite};
+use crate::{check_len, Error, Measure, Result, TryRead, TryWrite};
 use core::str;
 
 /// Context for &str to determine where a &str ends.
@@ -52,6 +52,13 @@ pub const SPACE: u8 = 0x20;
 pub const RET: u8 = 0x0a;
 /// Tab string delimiter
 pub const TAB: u8 = 0x09;
+
+impl Measure for &str {
+    #[inline]
+    fn measure(self, _: ()) -> usize {
+        self.len()
+    }
+}
 
 impl<'a> TryRead<'a, Str> for &'a str {
     #[inline]

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -332,13 +332,13 @@ fn test_api() {
 struct Empty;
 
 impl<'a> TryRead<'a, ()> for Empty {
-    fn try_read(bytes: &'a [u8], _ctx: ()) -> Result<(Self, usize)> {
+    fn try_read(_bytes: &'a [u8], _ctx: ()) -> Result<(Self, usize)> {
         Ok((Self, 0))
     }
 }
 
 impl TryWrite<()> for Empty {
-    fn try_write(self, bytes: &mut [u8], _ctx: ()) -> Result<usize> {
+    fn try_write(self, _bytes: &mut [u8], _ctx: ()) -> Result<usize> {
         Ok(0)
     }
 }


### PR DESCRIPTION
Another PR with some of my changes.
This aims to make the `TryWrite` trait more convenient to use by adding an `alloc` feature, that enables the user to convert values directly into bytes.
The way this is achieved is by adding a new `Measure` trait that can calculate the required size of the buffer for a value. This is used in a new `IntoBytesExt` extension trait, which is feature-gated behind `alloc` - it allocates a new `Vec` and writes the value into it.