### PR TITLE
Implement a derive macro

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-/target/
+target/
 **/*.rs.bk
 Cargo.lock

--- a/byte_derive/Cargo.toml
+++ b/byte_derive/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "byte"
+name = "byte_derive"
 version = "0.2.7"
 edition = "2021"
-authors = ["andylokandy"]
+authors = ["andylokandy", "jekky"]
 license = "MIT/Apache-2.0"
 
-description = "A low-level, zero-copy and panic-free serializer and deserializer for binary."
+description = "Derive macros for the byte crate"
 documentation = "https://docs.rs/byte"
 repository = "https://github.com/andylokandy/byte"
 homepage = "https://github.com/andylokandy/byte"
@@ -14,12 +14,13 @@ readme = "README.md"
 keywords = ["binary", "parser", "bytes", "scroll", "no_std"]
 categories = ["no-std", "embedded", "encoding", "parsing"]
 
-[dev-dependencies]
-quickcheck = "0.3"
-byteorder = "1.0.0"
-
-[features]
-derive = ["dep:byte_derive"]
+[lib]
+proc-macro = true
 
 [dependencies]
-byte_derive = { optional = true, path = "byte_derive" }
+proc-macro2 = "1"
+quote = "1"
+syn = "2"
+
+[dev-dependencies]
+byte = { path = "..", features = ["derive"] }

--- a/byte_derive/README.md
+++ b/byte_derive/README.md
@@ -1,0 +1,28 @@
+# byte_derive
+Derive macros for the `byte` crate.
+
+```rust
+use byte::{
+    ctx::{Str, NONE},
+    TryRead, TryWrite, LE,
+};
+
+#[derive(Debug, Clone, PartialEq, TryWrite, TryRead)]
+struct Named<'a> {
+    id: u32,
+    timestamp: f64,
+    #[byte(read_ctx = Str::Delimiter(0), write_ctx = NONE)]
+    str: &'a str,
+}
+
+fn main() {
+    let data: Named = Named {
+        id: 0x12345678,
+        timestamp: 1234.5678,
+        str: "hello",
+    };
+    let buf = &mut [0; 18];
+    data.clone().try_write(buf, LE).unwrap();
+    assert_eq!((data, 18), Named::try_read(buf, LE).unwrap());
+}
+```

--- a/byte_derive/src/lib.rs
+++ b/byte_derive/src/lib.rs
@@ -1,0 +1,215 @@
+use syn::{punctuated::Punctuated, spanned::Spanned};
+
+struct FieldAttributes {
+    read_ctx: Option<syn::Expr>,
+    write_ctx: Option<syn::Expr>,
+}
+
+fn impl_struct_read(
+    name: &syn::Ident,
+    struct_fields: &syn::Fields,
+    generics: &syn::Generics,
+) -> proc_macro2::TokenStream {
+    let mut lifetimes = generics.lifetimes();
+    let (_, ty_generics, where_clause) = generics.split_for_impl();
+
+    let mut generics = generics.clone();
+
+    // use the first lifetime parameter as the input lifetime if there is one
+    // otherwise create a new lifetime parameter and add it to the generics
+    let input_lt = if let Some(lt) = lifetimes.next() {
+        lt.clone()
+    } else {
+        let lt = syn::LifetimeParam::new(syn::Lifetime::new("'input", generics.span()));
+        generics
+            .params
+            .push_value(syn::GenericParam::Lifetime(lt.clone()));
+        generics.params.push_punct(syn::Token![,](generics.span()));
+        lt
+    };
+    let (impl_generics, _, _) = generics.split_for_impl();
+
+    let fields = match struct_fields {
+        syn::Fields::Named(fields) => &fields.named,
+        syn::Fields::Unnamed(fields) => &fields.unnamed,
+        syn::Fields::Unit => {
+            // no fields, so no bytes to read
+            return quote::quote! {
+                impl #impl_generics ::byte::TryRead<#input_lt, ::byte::ctx::Endian> for #name #ty_generics #where_clause {
+                    #[inline]
+                    fn try_read(bytes: & #input_lt [u8], ctx: ::byte::ctx::Endian) -> ::byte::Result<(Self, usize)> {
+                        Ok((Self, 0))
+                    }
+                }
+            };
+        }
+    };
+
+    if lifetimes.next().is_some() {
+        return syn::Error::new(
+            generics.span(),
+            "only one lifetime parameter is allowed for TryRead derive",
+        )
+        .to_compile_error();
+    }
+
+    let field_names = fields.iter().enumerate().map(|(i, field)| {
+        field
+            .ident
+            .clone()
+            .unwrap_or_else(|| syn::Ident::new(&format!("_{i}"), field.span()))
+    });
+
+    let field_reads = fields.iter().zip(field_names.clone()).map(|(field, name)| {
+        let attr = field.attrs.iter().find(|attr| attr.path().is_ident("byte"));
+        if let Some(attr) = attr {
+            match parse_field_attrs(attr) {
+                Ok(attrs) => {
+                    let read_ctx = attrs
+                        .read_ctx
+                        .map_or_else(|| quote::quote!(ctx), |ctx| quote::quote!(#ctx));
+                    quote::quote!(let #name = ::byte::BytesExt::read_with(bytes, offset, #read_ctx)?;)
+                }
+                Err(err) => err.to_compile_error(),
+            }
+        } else {
+            quote::quote!(let #name = ::byte::BytesExt::read_with(bytes, offset, ctx)?;)
+        }
+    });
+
+    let result = match struct_fields {
+        syn::Fields::Named(_) => quote::quote!(Self { #(#field_names),* }),
+        syn::Fields::Unnamed(_) => quote::quote!(Self( #(#field_names),* )),
+        syn::Fields::Unit => unreachable!(),
+    };
+
+    quote::quote! {
+        impl #impl_generics ::byte::TryRead<#input_lt, ::byte::ctx::Endian> for #name #ty_generics #where_clause {
+            fn try_read(bytes: & #input_lt [u8], ctx: ::byte::ctx::Endian) -> ::byte::Result<(Self, usize)> {
+                let mut offset = &mut 0;
+                #(#field_reads)*
+                Ok((#result, *offset))
+            }
+        }
+    }
+}
+
+fn impl_struct_write(
+    name: &syn::Ident,
+    struct_fields: &syn::Fields,
+    generics: &syn::Generics,
+) -> proc_macro2::TokenStream {
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
+    let fields = match struct_fields {
+        syn::Fields::Named(fields) => &fields.named,
+        syn::Fields::Unnamed(fields) => &fields.unnamed,
+        syn::Fields::Unit => {
+            // no fields, so no bytes to read
+            return quote::quote! {
+                impl #impl_generics ::byte::TryWrite<::byte::ctx::Endian> for #name #ty_generics #where_clause {
+                    #[inline]
+                    fn try_write(self, bytes: &mut [u8], ctx: ::byte::ctx::Endian) -> ::byte::Result<usize> {
+                        Ok(0)
+                    }
+                }
+            };
+        }
+    };
+
+    let field_names = fields.iter().enumerate().map(|(i, field)| {
+        field
+            .ident
+            .clone()
+            .unwrap_or_else(|| syn::Ident::new(&format!("_{i}"), field.span()))
+    });
+
+    let field_writes = fields.iter().zip(field_names.clone()).map(|(field, name)| {
+        if let Some(attr) = field.attrs.iter().find(|attr| attr.path().is_ident("byte")) {
+            match parse_field_attrs(attr) {
+                Ok(value) => {
+                    let write_ctx = value
+                        .write_ctx
+                        .map_or_else(|| quote::quote!(ctx), |ctx| quote::quote!(#ctx));
+                    quote::quote!(::byte::BytesExt::write_with(bytes, offset, #name, #write_ctx)?;)
+                }
+                Err(err) => err.to_compile_error(),
+            }
+        } else {
+            quote::quote!(::byte::BytesExt::write_with(bytes, offset, #name, ctx)?;)
+        }
+    });
+
+    let extract_fields = match struct_fields {
+        syn::Fields::Named(_) => Some(quote::quote! {
+            let #name { #(#field_names),* } = self;
+        }),
+        syn::Fields::Unnamed(_) => Some(quote::quote! {
+            let #name ( #(#field_names),* ) = self;
+        }),
+        syn::Fields::Unit => unreachable!(),
+    };
+
+    quote::quote! {
+        impl #impl_generics ::byte::TryWrite<::byte::ctx::Endian> for #name #ty_generics #where_clause {
+            fn try_write(self, bytes: &mut [u8], ctx: ::byte::ctx::Endian) -> ::byte::Result<usize> {
+                let mut offset = &mut 0;
+                #extract_fields
+                #(#field_writes)*
+                Ok(*offset)
+            }
+        }
+    }
+}
+
+fn impl_try_read(ast: &syn::DeriveInput) -> proc_macro2::TokenStream {
+    match &ast.data {
+        syn::Data::Struct(data) => impl_struct_read(&ast.ident, &data.fields, &ast.generics),
+        _ => syn::Error::new(ast.span(), "TryRead can only be derived for structs")
+            .to_compile_error(),
+    }
+}
+
+fn impl_try_write(ast: &syn::DeriveInput) -> proc_macro2::TokenStream {
+    match &ast.data {
+        syn::Data::Struct(data) => impl_struct_write(&ast.ident, &data.fields, &ast.generics),
+        _ => syn::Error::new(ast.span(), "TryWrite can only be derived for structs")
+            .to_compile_error(),
+    }
+}
+
+#[proc_macro_derive(TryRead, attributes(byte))]
+pub fn derive_try_read(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let ast = syn::parse_macro_input!(input as syn::DeriveInput);
+    let gen = impl_try_read(&ast);
+    gen.into()
+}
+
+#[proc_macro_derive(TryWrite, attributes(byte))]
+pub fn derive_try_write(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let ast = syn::parse_macro_input!(input as syn::DeriveInput);
+    let gen = impl_try_write(&ast);
+    gen.into()
+}
+
+fn parse_field_attrs(attr: &syn::Attribute) -> Result<FieldAttributes, syn::Error> {
+    let parser = Punctuated::<syn::MetaNameValue, syn::Token![,]>::parse_terminated;
+    let args = attr.meta.require_list()?.parse_args_with(parser)?;
+
+    let mut attributes = FieldAttributes {
+        read_ctx: None,
+        write_ctx: None,
+    };
+
+    for arg in args {
+        if arg.path.is_ident("read_ctx") {
+            attributes.read_ctx = Some(arg.value);
+        } else if arg.path.is_ident("write_ctx") {
+            attributes.write_ctx = Some(arg.value);
+        } else {
+            return Err(syn::Error::new(arg.path.span(), "unknown attribute"));
+        }
+    }
+
+    Ok(attributes)
+}

--- a/byte_derive/tests/tests.rs
+++ b/byte_derive/tests/tests.rs
@@ -1,0 +1,88 @@
+use byte::{
+    ctx::{Str, NONE},
+    TryRead, TryWrite, LE,
+};
+
+#[derive(Debug, Clone, PartialEq, TryWrite, TryRead)]
+struct Named<'a> {
+    id: u32,
+    timestamp: f64,
+    #[byte(read_ctx = Str::Delimiter(0), write_ctx = NONE)]
+    str: &'a str,
+}
+
+#[test]
+fn test_named_struct() {
+    let data: Named = Named {
+        id: 0x12345678,
+        timestamp: 1234.5678,
+        str: "hello",
+    };
+    let buf = &mut [0; 18];
+    data.clone().try_write(buf, LE).unwrap();
+    assert_eq!(Ok((data, 18)), Named::try_read(buf, LE));
+}
+
+#[derive(Debug, Clone, PartialEq, TryWrite, TryRead)]
+struct NoLifetime {
+    id: u32,
+    timestamp: f64,
+}
+
+#[test]
+fn test_no_lifetime_struct() {
+    let data = NoLifetime {
+        id: 0x12345678,
+        timestamp: 1234.5678,
+    };
+    let buf = &mut [0; 12];
+    data.clone().try_write(buf, LE).unwrap();
+    assert_eq!(Ok((data, 12)), NoLifetime::try_read(buf, LE));
+}
+
+#[derive(Debug, Clone, PartialEq, TryWrite, TryRead)]
+struct FieldDependent<'a> {
+    len: usize,
+    #[byte(read_ctx = Str::Len(len), write_ctx = NONE)]
+    str: &'a str,
+}
+
+#[test]
+fn test_len_dependent() {
+    let data = FieldDependent {
+        len: 2,
+        str: "hello",
+    };
+    let buf = &mut [0; 13];
+    data.clone().try_write(buf, LE).unwrap();
+    assert_eq!(
+        Ok((FieldDependent { len: 2, str: "he" }, 10)),
+        FieldDependent::try_read(buf, LE)
+    );
+}
+
+#[derive(Debug, Clone, PartialEq, TryRead, TryWrite)]
+struct Tuple<'a>(
+    u32,
+    f64,
+    #[byte(read_ctx = Str::Delimiter(0), write_ctx = NONE)] &'a str,
+);
+
+#[test]
+fn test_tuple_struct() {
+    let data: Tuple = Tuple(0x12345678, 1234.5678, "hello");
+    let buf = &mut [0; 18];
+    data.clone().try_write(buf, LE).unwrap();
+    assert_eq!(Ok((data, 18)), Tuple::try_read(buf, LE));
+}
+
+#[derive(Debug, Clone, PartialEq, TryRead, TryWrite)]
+struct Empty;
+
+#[test]
+fn test_empty_struct() {
+    let data: Empty = Empty;
+    let buf = &mut [0; 0];
+    data.clone().try_write(buf, LE).unwrap();
+    assert_eq!(Ok((data, 0)), Empty::try_read(buf, LE));
+}

--- a/src/ctx/mod.rs
+++ b/src/ctx/mod.rs
@@ -5,6 +5,9 @@ mod bytes;
 mod num;
 mod str;
 
+/// No context.
+pub const NONE: () = ();
+
 pub use self::bytes::*;
 pub use self::num::*;
 pub use self::str::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,6 +133,9 @@ pub mod ctx;
 use core::marker::PhantomData;
 pub use ctx::{BE, LE};
 
+#[cfg(feature = "derive")]
+pub use byte_derive::{TryRead, TryWrite};
+
 /// A specialized Result type for `Byte`
 pub type Result<T> = core::result::Result<T, Error>;
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -332,13 +332,13 @@ fn test_api() {
 struct Empty;
 
 impl<'a> TryRead<'a, ()> for Empty {
-    fn try_read(bytes: &'a [u8], _ctx: ()) -> Result<(Self, usize)> {
+    fn try_read(_bytes: &'a [u8], _ctx: ()) -> Result<(Self, usize)> {
         Ok((Self, 0))
     }
 }
 
 impl TryWrite<()> for Empty {
-    fn try_write(self, bytes: &mut [u8], _ctx: ()) -> Result<usize> {
+    fn try_write(self, _bytes: &mut [u8], _ctx: ()) -> Result<usize> {
         Ok(0)
     }
 }


### PR DESCRIPTION
Another PR with some of my changes.
This adds derive macros for `TryRead` and `TryWrite`.

Some notes:
- supports borrowed types as long as the target of the macro has exactly one lifetime
- doesn't support enums, only structs
- by default it generates impls where the `Ctx` is set to `Endian`, this is the most ergonomic option, but it could be made more flexible with a macro attribute in the future
- there's a `#[byte(read_ctx/write_ctx = ...)]` field attribute that allows specifying custom context per field, the context expression can use values of preceding fields in the struct
- the resulting `impl` is a bit awkward to use sometimes because `try_write` is defined to take `self` by value, which necessitates cloning - this could be worked around by having the derive generate an impl for &Self, but that'll not work when you nest structs, I think the best option would be to re-define `TryWrite` to take `&self` instead of `self`
- this PR would be pretty easy to extend to derive the `Measure` trait I've added in another PR

Usage
```rs
#[derive(Debug, Clone, PartialEq, TryWrite, TryRead)]
struct Named<'a> {
    id: u32,
    timestamp: f64,
    #[byte(read_ctx = Str::Delimiter(0), write_ctx = NONE)]
    str: &'a str,
}
```